### PR TITLE
Corrección de {} por ().

### DIFF
--- a/src/Components/Characters.js
+++ b/src/Components/Characters.js
@@ -16,9 +16,9 @@ const Characters = () => {
       {fetching ? (
         <Loading />
       ) : (
-        characters.map((character) => {
+        characters.map((character) => (
           <Character key={character.id} {...character} />;
-        })
+        ))
       )}
     </Row>
   );


### PR DESCRIPTION
Razón es porque el paréntesis devuelve ya un return implícito. En el caso de querer poner llaves, deberías poner un return y así sería lo mismo que hacer con parentesis